### PR TITLE
Subset

### DIFF
--- a/src/main/scala/dregex/Regex.scala
+++ b/src/main/scala/dregex/Regex.scala
@@ -89,6 +89,10 @@ trait Regex {
    */
   def doIntersect(other: Regex): Boolean = intersect(other).matchesAnything()
 
+  def isSubsetOf(other: Regex): Boolean =  !(this diff other matchesAnything)
+
+  def isProperSubsetOf(other: Regex): Boolean =  (this isSubsetOf other) && (other diff this matchesAnything) 
+
   /**
    * Return whether this regular expression is equivalent to other. Two regular expressions are equivalent if they
    * match exactly the same set of strings. This operation takes O(n*m) time, where n and m are the number of states of 

--- a/src/test/scala/dregex/OperationsTest.scala
+++ b/src/test/scala/dregex/OperationsTest.scala
@@ -8,6 +8,16 @@ class OperationsTest extends FunSuite {
     val Seq(leftCompiled, rightCompiled) = Regex.compile(Seq(left, right)).unzip._2
     leftCompiled doIntersect rightCompiled
   }
+
+  private def isSubset(left: String, right: String): Boolean = {
+    val Seq(leftCompiled, rightCompiled) = Regex.compile(Seq(left, right)).unzip._2
+    leftCompiled isSubsetOf rightCompiled
+  }
+
+  private def isProperSubset(left: String, right: String): Boolean = {
+    val Seq(leftCompiled, rightCompiled) = Regex.compile(Seq(left, right)).unzip._2
+    leftCompiled isProperSubsetOf rightCompiled
+  }
   
   private def testIntersection(left: String, right: String)(result: String): Boolean = {
     val Seq(leftCompiled, rightCompiled, resultCompiled) = Regex.compile(Seq(left, right, result)).unzip._2
@@ -27,6 +37,28 @@ class OperationsTest extends FunSuite {
     assertResult(false)(doIntersect("[^ab]", "[ab]"))
     assertResult(false)(doIntersect("[^ab]", "a|b"))
     assertResult(false)(doIntersect(".+", ""))
+  }
+
+  test("subset - boolean") {
+    assertResult(true) (isSubset("a", "."))
+    assertResult(true)(isSubset("", ".*"))
+    assertResult(true)(isSubset("a", "a"))
+    assertResult(true)(isSubset("(a|b){2}", "[ab][ab]"))
+    assertResult(false)(isSubset("[^a]", "[a]"))
+    assertResult(false)(isSubset("[abc]", "[ab]"))
+    assertResult(false)(isSubset("[^ab]", "a|b"))
+  }
+
+  test("proper subset - boolean") {
+    assertResult(true)(isProperSubset("a", "."))
+    assertResult(true)(isProperSubset("", ".*"))
+    assertResult(true)(isProperSubset("[ab]+", "[ab]*"))
+    assertResult(true)(isProperSubset("[ab]", "[abcd]"))
+    assertResult(false)(isProperSubset("a", "a"))
+    assertResult(false)(isProperSubset("(a|b){2}", "[ab][ab]"))
+    assertResult(false)(isProperSubset("[^a]", "[a]"))
+    assertResult(false)(isProperSubset("[abc]", "[ab]"))
+    assertResult(false)(isProperSubset("[^ab]", "a|b"))
   }
 
   test("intersections") {


### PR DESCRIPTION
I also have the following functions, which I did not add, but I could add to the Regex object, they're just some convenience functions. `findSubsetRelations` takes a list of strings and returns a list of pairs (a, b) where a is a subset of b.

```scala
  def findRelations(func: (Regex, Regex) => Boolean, xs: Seq[String]): Seq[(String, String)] = { 
    //TODO: make prettier and/or more efficient
    val rs = Regex compile xs
    val _perms = rs.combinations(2) ++ rs.combinations(2).map(_.reverse)
    val perms = _perms.map({case (x :: y :: Nil ) => (x, y)} ) 
    perms.filter( {case ((_, r1), (_, r2)) => func(r1, r2) }).map( {case ((s1, _), (s2, _)) => (s1, s2) }) toSeq
  }

  def findSubsetRelations(xs: Seq[String]): Seq[(String, String)] = findRelations(_ isSubsetOf _, xs)

  def findProperSubsetRelations(xs: Seq[String]): Seq[(String, String)] = findRelations(_ isProperSubsetOf _, xs)
```